### PR TITLE
all: enable TravisCI for integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: go
+env:
+  - I10R: "${TRAVIS_HOME}/gopath/src/github.com/interstellar/starlight"
+go:
+  - '1.11'
+branches:
+  only:
+    - main
+install: true
+script:
+  - go test -v ./starlight/starlighttest/... -timeout 60m # only integration

--- a/errors/doc.go
+++ b/errors/doc.go
@@ -4,7 +4,7 @@ annotated with additional information without losing the original error.
 
 Example:
 
-	import "i10r.io/errors"
+	import "github.com/interstellar/starlight/errors"
 
 	func query() error {
 		err := pq.Exec("SELECT...")

--- a/infra/services/starlight/deploy.sh
+++ b/infra/services/starlight/deploy.sh
@@ -4,7 +4,7 @@ set -ex
 host=ubuntu@starlight.i10rint.com
 tmpdir=$(mktemp -d)
 
-GOOS=linux GOARCH=amd64 go build -o $tmpdir/starlightd i10r.io/cmd/starlightd
+GOOS=linux GOARCH=amd64 go build -o $tmpdir/starlightd github.com/interstellar/starlight/cmd/starlightd
 ssh $host 'sudo systemctl stop starlight'
 scp $tmpdir/starlightd $host:~/starlightd
 ssh $host 'sudo systemctl start starlight'

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -298,8 +298,8 @@ func TestHelperStack(t *testing.T) {
 	got := string(read)
 	doNotWant := []string{
 		"log.go:",
-		"i10r.io/log.Printkv",
-		"i10r.io/log.Error",
+		"github.com/interstellar/starlight/log.Printkv",
+		"github.com/interstellar/starlight/log.Error",
 	}
 
 	t.Logf("output:\n%s", got)

--- a/starlight/httperror.go
+++ b/starlight/httperror.go
@@ -10,7 +10,7 @@ import (
 	"github.com/interstellar/starlight/starlight/fsm"
 )
 
-// TODO(vniu): refactor i10r.io/net/httperror to avoid
+// TODO(vniu): refactor github.com/interstellar/starlight/net/httperror to avoid
 // code duplication.
 
 // Defines the exported errors that are used by the Starlight


### PR DESCRIPTION
Replace `i10r.io` references with `github.com/interstellar/starlight`
to further decouple from Interstellar's internal monorepo.