### PR TITLE
starlight/agent: fix sequence number bug

### DIFF
--- a/starlight/agent.go
+++ b/starlight/agent.go
@@ -670,7 +670,6 @@ func (g *Agent) watchWalletAcct(acctID string, cursor horizon.Cursor) {
 					w.Reserve = 2 * baseReserve
 					w.Seqnum = seqnum
 					w.Cursor = htx.PT
-					root.Agent().PutWallet(w)
 					g.putUpdate(root, &Update{
 						Type: update.AccountType,
 						Account: &update.Account{
@@ -707,6 +706,7 @@ func (g *Agent) watchWalletAcct(acctID string, cursor horizon.Cursor) {
 						// create transaction to set options
 						g.addTxTask(root.Tx(), walletBucket, *env.E)
 					}
+					root.Agent().PutWallet(w)
 
 				case xdr.OperationTypePayment:
 					paymentOp := op.Body.PaymentOp

--- a/starlight/agent.go
+++ b/starlight/agent.go
@@ -668,7 +668,7 @@ func (g *Agent) watchWalletAcct(acctID string, cursor horizon.Cursor) {
 					hostFeerate := root.Agent().Config().HostFeerate()
 					w.NativeBalance = xlm.Amount(createAccount.StartingBalance) - xlm.Amount(hostFeerate) - 2*baseReserve
 					w.Reserve = 2 * baseReserve
-					w.Seqnum = seqnum + 1
+					w.Seqnum = seqnum
 					w.Cursor = htx.PT
 					root.Agent().PutWallet(w)
 					g.putUpdate(root, &Update{
@@ -685,6 +685,7 @@ func (g *Agent) watchWalletAcct(acctID string, cursor horizon.Cursor) {
 					if root.Agent().Config().Public() {
 						// Set account home domain
 						domain := w.Address[strings.Index(w.Address, "*")+1:]
+						w.Seqnum++
 						tx, err := b.Transaction(
 							b.Network{Passphrase: g.passphrase(root)},
 							b.BaseFee{Amount: uint64(hostFeerate)},


### PR DESCRIPTION
Fixes bug where running `starlightd` agent manually without public configuration results in bad sequence number errors since we don't publish the transaction setting home domain for private agents.